### PR TITLE
Fix missing getOffers helper

### DIFF
--- a/src/components/OffersList.tsx
+++ b/src/components/OffersList.tsx
@@ -2,6 +2,20 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
 
+async function getOffers() {
+  const { data, error } = await supabase
+    .from('offers')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    console.error('Błąd pobierania ofert:', error.message)
+    return []
+  }
+
+  return data || []
+}
+
 export default function OffersList({ onSelect }) {
   const [offers, setOffers] = useState([])
   useEffect(() => {


### PR DESCRIPTION
## Summary
- implement `getOffers` helper in `OffersList` component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409fe319cc8329ab38fbfed7c036a3