### PR TITLE
Fix Tailwind config export

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,11 +25,4 @@ module.exports = {
   plugins: [
     require('@tailwindcss/line-clamp'),
   ],
-}
-
-module.exports = {
-  darkMode: 'class',
-  content: ['./app/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
-  theme: { extend: {} },
-  plugins: [],
 };


### PR DESCRIPTION
## Summary
- remove duplicate `module.exports` block from Tailwind config

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a777d6f0832997ee81e7e86aa22e